### PR TITLE
Support AWS Credential profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The rotate-ec2-key.sh script accepts the following command line options:
 4. Re-test.
 5. If nothing breaks, delete the old key.
 
-The script does a fairly simple test in step #4: it merely attempts to get an object from S3, and if it’s successful,
+The script does a fairly simple test in step #4: it merely attempts to list the access keys for the user, and if it’s successful,
 the test passes. The actual tests used in your production environment will likely be more extensive and will vary based
 on your business requirements.
 
@@ -62,8 +62,8 @@ The rotate-iam-key.sh script accepts the following command line options:
                         have the rights to list and update credentials for the IAM user. The script expects the .csv format
                         used when you download the key from IAM in the AWS console. If this option is not specified,
                         existing AWS CLI credentials must be already defined and are used.
-     -s --s3-test-file  Specifies a test text file stored in S3 used for testing. Required. The IAM user must have
-                        GET access to this file.
+		 -p --profile       If using a AWS credential profile, specify the name of the profile here to rotate
+		                    it's credentials.
      -c --csv-key-file  The name of the output .csv file containing the new access key information. Optional.
      -u --user          The IAM user whose key you want to rotate. Required.
      -j --json          A file to send JSON output to. Optional.

--- a/rotate-iam-user-key.sh
+++ b/rotate-iam-user-key.sh
@@ -59,7 +59,7 @@ __base="$(basename ${__file} .sh)"
 IAM_USER=
 AWS_KEY_FILE=
 JSON_OUTPUT_FILE=
-CSV_OUTPUT_FILE=
+#CSV_OUTPUT_FILE=
 RECONFIGURE=
 
 # Check if any arguments were passed. If not, print an error
@@ -139,6 +139,7 @@ function VerifyAwsProfile() {
         exit 5
     else
         export AWS_PROFILE=$AWS_PROFILE
+        export AWS_DEFAULT_PROFILE=$AWS_PROFILE
     fi
 
 }
@@ -230,8 +231,13 @@ if [ "$SUCCESS" = true ]; then
   if [ "$SUCCESS" = true ]; then
     if [[ ! -z "$RECONFIGURE" ]]; then
       echo "Successfully used new key after inactivating the old key. Reconfiguring AWS CLI with new key..."
-      aws configure set aws_access_key_id "$NEW_AWS_ACCESS_KEY_ID"
-      aws configure set aws_secret_access_key "$NEW_AWS_SECRET_ACCESS_KEY"
+      if [[ ! -z "$AWS_PROFILE" ]]; then
+        aws configure --profile "$AWS_PROFILE" set aws_access_key_id "$NEW_AWS_ACCESS_KEY_ID"
+        aws configure --profile "$AWS_PROFILE" set aws_secret_access_key "$NEW_AWS_SECRET_ACCESS_KEY"
+      else
+        aws configure set aws_access_key_id "$NEW_AWS_ACCESS_KEY_ID"
+        aws configure set aws_secret_access_key "$NEW_AWS_SECRET_ACCESS_KEY"
+      fi
     fi
     echo "Deleting the old key..."
     aws iam delete-access-key --profile temp-role --user-name "$IAM_USER" --access-key-id "$EXISTING_KEY_ID"


### PR DESCRIPTION
Support AWS Credential profiles by setting environmental variable that is used by aws cli. Included a verification step which just grabs the access key via `aws configure`.